### PR TITLE
Tighten up the popup so it does not overlap the earnings table

### DIFF
--- a/content.js
+++ b/content.js
@@ -109,6 +109,7 @@ function prepare() {
     .container {
         overflow: hidden;
         margin-bottom: 50px;
+        margin-top: 6px;
     }
     .column {
         float: left;

--- a/popup.css
+++ b/popup.css
@@ -1,16 +1,21 @@
+body {
+  margin: 3px 10px;
+  white-space: nowrap;
+  font-size: max(14px, 1em);
+}
+
 #symbol {
-  font-size: 20px;
-  font-size: max(20px, 1em);
+  display: inline-block;
   font-family: inherit;
   padding: 0.10em 0.25em;
+  margin: 0.10em 0.5em;
   background-color: #fff;
-  border: 2px solid var(--input-border);
+  border: 2px solid;
   border-radius: 4px;
   width: 75px;
+  text-transform: uppercase;
 }
 
 #options {
   font-size: 10px;
-  padding-bottom: 3px;
-  float: right;
 }

--- a/popup.html
+++ b/popup.html
@@ -7,10 +7,10 @@
     <link rel="stylesheet" href="popup.css">
   </head>
   <body>
-    <div id="content">           
-        <label for="text-input">Enter symbol:</label>        
-        <input id="symbol" maxlength="5" />  
-    </div> 
-    <a id="options" href="options.html">Options</a>     
+    <div id="content">
+      <span>Symbol</span>
+      <input id="symbol" maxlength="5" />
+      <a id="options" href="options.html" tabindex="-1">Options</a>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Tightened up the layout of the popup so it does not cover the earnings table.

These tweaks combined with disabling "Always open in a new tab" makes surfing earnings super-fast and convenient.

Also fixed the disappearing border bug on some browsers / operating systems.